### PR TITLE
FISH-6858 Fix Malformed OSGi

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -9,7 +9,7 @@
 
     <groupId>org.jboss.classfilewriter</groupId>
     <artifactId>jboss-classfilewriter</artifactId>
-    <version>1.3.0.Final.payara-p1</version>
+    <version>1.3.0.Final.payara-p2-SNAPSHOT</version>
 
     <packaging>jar</packaging>
     <description>A bytecode writer that creates .class files at runtime</description>

--- a/pom.xml
+++ b/pom.xml
@@ -71,6 +71,7 @@
                         <Export-Package>
                             org.jboss.classfilewriter.*;version=${project.version}
                         </Export-Package>
+                        <Import-Package>!java.*,*</Import-Package>
                     </instructions>
                 </configuration>
                 <executions>

--- a/pom.xml
+++ b/pom.xml
@@ -9,7 +9,7 @@
 
     <groupId>org.jboss.classfilewriter</groupId>
     <artifactId>jboss-classfilewriter</artifactId>
-    <version>1.3.0.Final.payara-p1-SNAPSHOT</version>
+    <version>1.3.0.Final.payara-p1</version>
 
     <packaging>jar</packaging>
     <description>A bytecode writer that creates .class files at runtime</description>

--- a/pom.xml
+++ b/pom.xml
@@ -62,7 +62,7 @@
             <plugin>
                 <groupId>org.apache.felix</groupId>
                 <artifactId>maven-bundle-plugin</artifactId>
-                <version>3.3.0</version>
+                <version>5.1.9</version>
                 <extensions>true</extensions>
                 <configuration>
                     <instructions>


### PR DESCRIPTION
The vanilla 1.3.0.Final release has malformed OSGi, with the `osgi.ee` filter being set to `UNKNOWN`. This is fixed by using a more recent version of the Maven Bundle plugin.

This however also starts importing `java.*` packages by default (the ones from the JDK), which we don't currently support, so there's also an additional change to make it so that these packages are excluded.